### PR TITLE
readVisible(): Read from both visual registers

### DIFF
--- a/Adafruit_SI1145.cpp
+++ b/Adafruit_SI1145.cpp
@@ -116,7 +116,12 @@ uint16_t Adafruit_SI1145::readUV(void) {
 
 // returns visible+IR light levels
 uint16_t Adafruit_SI1145::readVisible(void) {
- return read16(0x22); 
+ uint16_t val = 0;
+
+ val = read8(SI1145_REG_ALSVISDATA0);
+ val |= read8(SI1145_REG_ALSVISDATA1) << 8;
+
+ return val;
 }
 
 // returns IR light levels


### PR DESCRIPTION
Each visible register returns an 8 bit value according to the datasheet[1].
Trying to make an 8 bit number into a 16 bit number appears to result in
a bad value (ie 65532).  The same is true for readIr() but I don't address
that issue in this patch.

[1] - Page 30: https://www.silabs.com/Support%20Documents/TechnicalDocs/Si1145-46-47.pdf